### PR TITLE
Fixed Sonar + Jacoco code coverage analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
         <log4j.version>2.11.2</log4j.version>
         <slf4j.version>1.7.26</slf4j.version>
         <spring.core.version>5.1.4.RELEASE</spring.core.version>
+
+        <!-- Sonar -->
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.jacoco.reportPath>${project.basedir}/../target/jacoco.exec</sonar.jacoco.reportPath>
     </properties>
 
     <scm>
@@ -85,6 +90,10 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
+                <configuration>
+                    <destFile>${sonar.jacoco.reportPath}</destFile>
+                    <append>true</append>
+                </configuration>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/task-flow-core/pom.xml
+++ b/task-flow-core/pom.xml
@@ -21,7 +21,8 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--add-opens taskflow.core.tasks/br.com.miguelfontes.taskflow.core=ALL-UNNAMED</argLine>
+                    <argLine>@{argLine} --add-opens taskflow.core.tasks/br.com.miguelfontes.taskflow.core=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/task-flow-grpc-dist/pom.xml
+++ b/task-flow-grpc-dist/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>task-flow-grpc-dist</artifactId>
 
-    <name>task-flow-grpc-dist</name>
+    <name>Task Flow gRPC Distribution</name>
     <url>https://github.com/Miguel-Fontes/task-flow</url>
     <description>Assembles and and builds a gRPC based distribution of the Task Flow project</description>
 

--- a/task-flow-grpc-test/pom.xml
+++ b/task-flow-grpc-test/pom.xml
@@ -11,7 +11,7 @@
 
     <artifactId>task-flow-grpc-test</artifactId>
 
-    <name>task-flow-grpc-test</name>
+    <name>Task Flow gRPC Test</name>
     <url>https://github.com/Miguel-Fontes/task-flow</url>
     <description>A integration testing module for a gRPC based distribution</description>
 

--- a/task-flow-persistence-mmdb/pom.xml
+++ b/task-flow-persistence-mmdb/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--add-opens
+                    <argLine>@{argLine} --add-opens
                         taskflow.persistence.mmdb/br.com.miguelfontes.taskflow.persistence.mmdb=ALL-UNNAMED
                     </argLine>
                 </configuration>

--- a/task-flow-tasks/pom.xml
+++ b/task-flow-tasks/pom.xml
@@ -21,7 +21,8 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>--add-opens taskflow.tasks/br.com.miguelfontes.taskflow.tasks=ALL-UNNAMED</argLine>
+                    <argLine>@{argLine} --add-opens taskflow.tasks/br.com.miguelfontes.taskflow.tasks=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
* By using java 11 with the new Java module system, we needed to make sure Junit5 tests can be accessed by the usage of the `--add-opens` argument line configuration (on the  `<argLine>` setting of the maven sure fire plugin), but without preceding it with `@{argLine}` all Jacoco arguments defined by the plugin were lost - thus, no code coverage report was generated.
* Additionally, as we're using a new test module (task-flow-grpc-test), the coverage report generation strategy was changed to 'append'. Otherwise, jacoco would not generate a report for this module, since there's no production code on it.