### PR TITLE
Restore Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 sudo: false
 
 script:
-- mvn test -B
+  - mvn test jacoco:report -B
 
 before_deploy:
 - tar -zcf $TRAVIS_BUILD_DIR/$OUTPUT_DIR/$TRAVIS_TAG.tar.gz -C $TRAVIS_BUILD_DIR/$OUTPUT_DIR $(find $TRAVIS_BUILD_DIR/$OUTPUT_DIR/ -maxdepth 1 -name $ARTIFACT_NAME-*$ARTIFACT_EXTENSION -printf "%f\n")

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+  - "**/task-flow-ports-*"
+  - "**/Application.java"
+  - "**/GrpcServer.java"

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.3</version>
                 <configuration>
+                    <dataFile>${sonar.jacoco.reportPath}</dataFile>
                     <destFile>${sonar.jacoco.reportPath}</destFile>
                     <append>true</append>
                 </configuration>


### PR DESCRIPTION
* With the jacoco append configuration, Codecov had stopped working.
* Added the datafile configuration do jacoco-maven-plugin, restoring the jacoco.xml report generation.
* The problem was happening because jacoco searches for the execution data file (jacoco.exec) inside each module path by default and it was changed to ${baseProjectDir}/target..
* Also, the travis script was changed to generated the coverage report before trying to upload to codecov (makes sense, ain't it?)..